### PR TITLE
NODE-3125: make RUBYLIB env var depend on distr

### DIFF
--- a/env
+++ b/env
@@ -1,7 +1,13 @@
 #!/bin/sh
 
 export LD_LIBRARY_PATH=/app/wallarm/lib:/app/wallarm/lib/python2.7/config-x86_64-linux-gnu
-export RUBYLIB=/app/wallarm/lib/ruby/vendor_ruby:/app/wallarm/lib/ruby/vendor_ruby/1.9.1:/app/wallarm/lib/ruby/vendor_ruby/2.3.0:/app/wallarm/lib/ruby/vendor_ruby/1.9.1/x86_64-linux
+export RUBYLIB=/app/wallarm/lib/ruby/vendor_ruby
+if [ `grep -q "VERSION_CODENAME=bionic" /etc/os-release` ]; then
+	export RUBYLIB=$RUBYLIB:/app/wallarm/lib/ruby/vendor_ruby/2.5.0:/app/wallarm/share/rubygems-integration/all/gems/mime-types-3.1/lib/
+elif [ `grep -q "VERSION_CODENAME=xenial" /etc/os-release` ]; then
+	export RUBYLIB=$RUBYLIB:/app/wallarm/lib/ruby/vendor_ruby/2.3.0:
+fi
+
 export PYTHONPATH=/app/wallarm/lib/python2.7/dist-packages
 export LUA_CPATH="/app/wallarm/lib/tarantool/?.so"
 export LUA_PATH="/app/wallarm/share/tarantool/?.lua;/app/wallarm/share/tarantool/?/init.lua"


### PR DESCRIPTION
Ruby versions on xenial and bionic are not the same. Addnode script
failed due to the difference in paths to msgpack and mime/type.